### PR TITLE
fix: cross-platform cron scheduler + manual trigger endpoints

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,194 @@
+# Architecture
+
+## System Overview
+
+Order is an agentic life order system that gathers scattered commitments from multiple sources and surfaces them through different interaction modes.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Frontend                              │
+│                    (Next.js + Tailwind)                      │
+│   ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐     │
+│   │Drown │ │Scatt │ │Stuck │ │Accum │ │Spec  │ │Ready │     │
+│   └──┬───┘ └──┬───┘ └──┬───┘ └──┬───┘ └──┬───┘ └──┬───┘     │
+│      │        │        │        │        │        │          │
+│   ┌──┴────────┴────────┴────────┴────────┴────────┴───┐     │
+│   │              Mode Selector                         │     │
+│   └────────────────────┬──────────────────────────────┘     │
+└────────────────────────┼─────────────────────────────────────┘
+                         │ HTTP/SSE
+┌────────────────────────┼─────────────────────────────────────┐
+│                        │ Backend                             │
+│                        ▼                                     │
+│   ┌─────────────────────────────────────────────────────┐   │
+│   │                   FastAPI                            │   │
+│   │  /api/one-thing  /api/gather  /api/chat  ...       │   │
+│   └────────────────────┬────────────────────────────────┘   │
+│                        │                                     │
+│   ┌────────────────────┼────────────────────────────────┐   │
+│   │                    ▼                                 │   │
+│   │   ┌──────────┐  ┌──────────┐  ┌──────────┐          │   │
+│   │   │  Modes   │  │ Synthesis│  │   Cron   │          │   │
+│   │   │  (6)     │  │  (LLM)   │  │ Scheduler│          │   │
+│   │   └────┬─────┘  └────┬─────┘  └────┬─────┘          │   │
+│   │        │             │             │                 │   │
+│   │        └─────────────┼─────────────┘                 │   │
+│   │                      ▼                               │   │
+│   │            ┌──────────────────┐                      │   │
+│   │            │  SQLite Store    │                      │   │
+│   │            │  (async)         │                      │   │
+│   │            └──────────────────┘                      │   │
+│   └──────────────────────────────────────────────────────┘   │
+│                        │                                     │
+│   ┌────────────────────┼────────────────────────────────┐   │
+│   │                    ▼      Gatherers                   │   │
+│   │   ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐   │   │
+│   │   │ Discord │ │ GitHub  │ │    X    │ │  Gmail  │   │   │
+│   │   │TinyFish │ │API      │ │TinyFish │ │TinyFish │   │   │
+│   │   └────┬────┘ └────┬────┘ └────┬────┘ └────┬────┘   │   │
+│   └────────┼───────────┼───────────┼───────────┼─────────┘   │
+└────────────┼───────────┼───────────┼───────────┼─────────────┘
+             │           │           │           │
+         ┌───┴───┐   ┌───┴───┐   ┌───┴───┐   ┌───┴───┐
+         │Discord│   │GitHub │   │   X   │   │ Gmail │
+         └───────┘   └───────┘   └───────┘   └───────┘
+```
+
+## Core Components
+
+### 1. Gatherers
+Collect commitments from external sources.
+
+| Source | Method | When |
+|--------|--------|------|
+| Discord | TinyFish SSE | No API for message search |
+| GitHub | REST API | Issues assigned, PRs awaiting review |
+| X (Twitter) | TinyFish SSE | DMs, bookmarks |
+| Gmail | TinyFish SSE | Actionable emails |
+
+**Base Pattern**:
+```python
+class BaseGatherer(ABC):
+    @abstractmethod
+    async def gather(self) -> AsyncIterator[Commitment]: ...
+    
+    async def run(self) -> GatherResult:
+        # Collect all commitments, return result
+```
+
+### 2. SQLite Store
+Async persistence with SQLAlchemy ORM.
+
+```python
+class CommitmentRow(Base):
+    id: str              # UUID
+    source: str          # discord, github, x_dm, x_bookmark, gmail
+    text: str            # Original message
+    extracted_task: str  # AI-extracted task
+    deadline: datetime   # Optional
+    priority: int        # 0-3
+    status: str          # pending, done, ignored, expired
+    raw_data: JSON       # Full original data
+```
+
+### 3. AI Synthesis
+LiteLLM-based filtering and prioritization.
+
+```python
+async def extract_commitment(text, source) -> dict
+async def filter_commitments(commitments) -> List[Commitment]
+async def prioritize_commitments(commitments) -> List[Commitment]
+async def pick_one_thing(commitments) -> Commitment
+```
+
+**Fallback**: Works without LLM API key (simple priority sorting).
+
+### 4. Cron Scheduler
+Hermes-style file-based scheduler with tick pattern.
+
+```python
+class CronScheduler:
+    def register(name, job_func)
+    def run_in_background()
+    # Uses fcntl for file locking
+    # Tick every 60 seconds
+```
+
+**Jobs**:
+- `gather_all` (every 5 min)
+- `reduce_all` (every 10 min)
+- `expire_old` (every hour)
+
+### 5. Modes
+Six interaction modes for different mental states.
+
+| Mode | State | Behavior |
+|------|-------|----------|
+| One-Thing | Drowning | Show only ONE commitment |
+| Gather | Scattered | Pull from all sources |
+| Reduce | Accumulated | Filter noise, keep what matters |
+| Conversation | Stuck | Thinking partner chat |
+| Just-in-Time | Specific | Ask and receive, no storage |
+| Executor | Ready | Agents handle tasks |
+
+## Data Flow
+
+```
+1. User connects accounts (Discord, GitHub, X, Gmail)
+2. Cron jobs gather commitments periodically
+3. AI synthesis filters and prioritizes
+4. Modes surface based on user's state
+5. User acts (done, skip, delegate)
+6. Status updates reflect in stats
+```
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|------------|
+| Frontend | Next.js 16, Tailwind, Bun |
+| Backend | FastAPI, uvicorn |
+| Storage | SQLite (async) + SQLAlchemy |
+| AI | LiteLLM (any provider) |
+| Scraping | TinyFish (authenticated browser) |
+| Cron | Hermes-style file-based |
+| Runtime | Python 3.13, uv |
+
+## Key Design Decisions
+
+### Why TinyFish?
+Discord and X have no APIs for message search. TinyFish provides authenticated browser automation via SSE streaming.
+
+### Why SQLite?
+Simple, async, no server needed. Perfect for personal tool.
+
+### Why 6 Modes?
+Different chaos states need different interactions. One-size-fits-all doesn't work.
+
+### Why Fallback Mode?
+Production should work without LLM. Simple priority sorting is better than nothing.
+
+## File Structure
+
+```
+order/
+├── src/order/
+│   ├── core/           # Models, config, store
+│   ├── gatherers/      # TinyFish + API gatherers
+│   ├── synthesis/      # LLM integration
+│   ├── modes/          # 6 interaction modes
+│   ├── cron/           # Background jobs
+│   └── api.py          # FastAPI endpoints
+│
+└── frontend/
+    ├── app/            # Next.js pages
+    ├── components/     # Mode views
+    └── lib/            # API client
+```
+
+## Security Considerations
+
+- API keys stored in environment variables
+- No user data stored permanently (commitments expire)
+- TinyFish handles authentication (no credentials stored)
+- Fallback mode works without external APIs

--- a/docs/manifesto.md
+++ b/docs/manifesto.md
@@ -1,0 +1,141 @@
+# Order Manifesto
+
+## The Problem
+
+Your commitments are scattered. Discord messages, GitHub issues, X DMs, emails—each holds a piece of what you promised to do. 
+
+You tried Notion. You tried Obsidian. You tried every todo app.
+
+They all failed for the same reason: **they require you to do the work**.
+
+- Open the app
+- Write down what you need to do
+- Organize it
+- Check it later
+- Feel guilty when you don't
+
+This is **productivity theater**. It's not solving the problem—it's creating new work.
+
+## The Real Problem
+
+In the AI era, the problem isn't organization. It's:
+
+1. **Context Collapse** - Your commitments live in 10 different places
+2. **Information Bankruptcy** - You can't remember what you promised
+3. **Attention Fragmentation** - Every tool demands its own context
+4. **Cognitive Overload** - More tools = more mental load
+
+The average knowledge worker has **commitments scattered across 5+ platforms**. Each one invisible to the others.
+
+You don't need a better tool. You need **something that finds what you already said you'd do**.
+
+## The Solution
+
+**Order** doesn't ask you to organize. It finds what you already promised.
+
+### Core Principles
+
+1. **Zero Setup** - Connect accounts, done. No methodology to learn.
+2. **Pull, Don't Push** - We find your commitments. You don't enter them.
+3. **Multiple Paths** - Different chaos states need different interactions.
+4. **Radical Simplicity** - One-Thing mode shows only ONE commitment.
+5. **Always Fresh** - Background jobs keep it updated automatically.
+6. **Agentic** - Not just tracking. Agents can handle tasks.
+
+### Why 6 Modes?
+
+Because chaos isn't one-dimensional.
+
+| State | What You Feel | What You Need |
+|-------|---------------|---------------|
+| Drowning | "I can't think" | ONE thing |
+| Scattered | "I don't know what I promised" | Gather all |
+| Stuck | "I know but I can't start" | Thinking partner |
+| Accumulated | "Too much on my plate" | Filter noise |
+| Specific | "What about X?" | Just-in-time answer |
+| Ready | "Let's do this" | Execute |
+
+One-size-fits-all doesn't work. You need different tools for different states.
+
+### Why TinyFish?
+
+Discord and X don't have APIs for message search. But that's where your commitments live.
+
+TinyFish provides authenticated browser automation. We can:
+- Search Discord messages for promises
+- Find X DMs and bookmarks
+- Process Gmail for actionable emails
+
+No manual entry. No copying. Just connect and done.
+
+## The Anti-Productivity Product
+
+Order is the **anti-Notion**.
+
+| Notion | Order |
+|--------|-------|
+| Manual entry | Automatic gathering |
+| Single workspace | Multi-source sync |
+| You organize | AI filters |
+| Learning curve | Zero setup |
+| More tools | Less tools |
+| Productivity theater | Pull your actual commitments |
+
+## The Philosophy
+
+### 1. Life is Chaos
+Stop pretending you'll organize it. You won't. We know.
+
+### 2. Commitments are Scattered
+They live where you made them. Go find them there.
+
+### 3. One Thing at a Time
+When drowning, you don't need 100 commitments. You need ONE.
+
+### 4. Context is Everything
+Different states need different tools. Match the tool to the state.
+
+### 5. Less is More
+No features you won't use. No setup you'll skip. No learning curve.
+
+## The Vision
+
+**Order** brings order to chaos without requiring you to change.
+
+- Connect your accounts once
+- Background jobs keep it fresh
+- AI surfaces what matters
+- You act when ready
+
+No manual entry. No organization. No guilt.
+
+**Just order from chaos.**
+
+---
+
+## For the Hackathon
+
+This is a TinyFish-powered demo for the HackerEarth pre-accelerator.
+
+**What we're building:**
+- TinyFish gatherers for Discord, X, Gmail
+- GitHub API for issues/PRs
+- 6 interaction modes
+- AI synthesis with LiteLLM
+- Background cron jobs
+
+**What we're proving:**
+- Pulling commitments from scattered sources works
+- Multiple modes for different chaos states is valuable
+- Zero-setup productivity is possible
+
+**What we're NOT building:**
+- Another Notion
+- Another todo app
+- Another productivity methodology
+
+**We're building** the thing that finds what you already promised.
+
+---
+
+*Order brings order to chaos. Not by adding more tools, but by finding what's already there.*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,203 @@
+# Roadmap
+
+## TinyFish Hackathon Sprint
+
+**Goal**: Demo-ready for HackerEarth pre-accelerator submission
+
+**Timeline**: 2-3 weeks
+
+---
+
+## Phase 1: MVP Foundation (Week 1)
+
+### Goal
+Get core functionality working end-to-end.
+
+### Tasks
+- [ ] Backend runs without errors
+- [ ] Frontend connects to backend
+- [ ] One-Thing mode works
+- [ ] Gather mode shows mock data
+- [ ] Basic error handling
+- [ ] README with setup instructions
+
+### Acceptance Criteria
+- `uv run uvicorn order.api:app` starts server
+- `bun run dev` shows frontend
+- Clicking through modes doesn't crash
+- At least one commitment shows in One-Thing
+
+### GitHub Issues
+- #1 MVP Demo Ready
+- #11 6 Modes End-to-End Testing
+
+---
+
+## Phase 2: Integrations + AI (Week 1-2)
+
+### Goal
+Real data flowing from sources, AI working.
+
+### Tasks
+- [ ] TinyFish API key configuration
+- [ ] Discord gatherer with real account
+- [ ] X (Twitter) gatherer with real account
+- [ ] GitHub gatherer with real PAT
+- [ ] Gmail gatherer with real account
+- [ ] Test AI synthesis quality
+- [ ] Add fallback mode
+
+### Acceptance Criteria
+- All 4 sources show as connected
+- Gather pulls real commitments
+- AI filters noise correctly
+- Works without LLM API key
+
+### GitHub Issues
+- #2 Source Integrations
+- #10 AI Synthesis Quality
+
+---
+
+## Phase 3: Polish + Pitch (Week 2)
+
+### Goal
+Production-ready for demo, compelling pitch.
+
+### Tasks
+- [ ] Improve mode selector UX
+- [ ] Add loading states
+- [ ] Add animations/transitions
+- [ ] Error states with retry
+- [ ] Empty states
+- [ ] Source icons
+- [ ] Deadline indicators
+- [ ] Create pitch deck (8-10 slides)
+- [ ] Record demo video (60-90s)
+
+### Acceptance Criteria
+- Feels like a polished product
+- Pitch deck ready
+- Demo video uploaded
+
+### GitHub Issues
+- #3 Frontend Polish
+- #4 Pitch Deck
+- #5 Demo Video
+
+---
+
+## Phase 4: Deployment (Week 2-3)
+
+### Goal
+Live demo URL for judges.
+
+### Tasks
+- [ ] Deploy backend to Railway/Fly.io
+- [ ] Deploy frontend to Vercel
+- [ ] Set environment variables
+- [ ] Test all endpoints
+- [ ] Add deployment badges
+
+### Acceptance Criteria
+- Live URL works
+- All API endpoints accessible
+- Frontend connects to backend
+
+### GitHub Issues
+- #6 Deployment
+
+---
+
+## Hackathon Submission Checklist
+
+- [ ] Working demo (live URL or video)
+- [ ] Pitch deck (PDF)
+- [ ] Demo video (60-90s)
+- [ ] Code repository (public)
+- [ ] README with setup
+- [ ] TinyFish integration prominent
+
+---
+
+## Post-Hackathon Roadmap
+
+### Phase 5: Production Ready
+- Rate limiting
+- Input validation
+- Proper CORS
+- Error logging
+- Health monitoring
+- **Issue #7 Security**
+
+### Phase 6: Quality of Life
+- Email digests
+- Mobile responsive polish
+- Keyboard shortcuts
+- Better error messages
+- **Issue #8 Email Digest**
+
+### Phase 7: Scale
+- Multi-user support
+- Team workspaces
+- Shared commitments
+- Integrations (Slack, Teams)
+- Webhooks
+
+### Phase 8: Intelligence
+- Better AI extraction
+- Deadline prediction
+- Commitment patterns
+- Smart reminders
+- Priority learning
+
+---
+
+## Success Metrics
+
+### Hackathon
+- ✅ Demo works live
+- ✅ Pitch deck compelling
+- ✅ TinyFish integration shown
+- ✅ All 6 modes functional
+
+### Post-Hackathon
+- Real users actually using it
+- Commitments gathered per week
+- Time saved vs manual organization
+- User retention
+
+---
+
+## Timeline Visualization
+
+```
+Week 1          Week 2          Week 3
+├───────────────┼───────────────┼───────────────┤
+│ Phase 1       │ Phase 3       │ Phase 4       │
+│ MVP           │ Polish        │ Deploy        │
+│               │               │               │
+│ Phase 2       │ Phase 3       │ SUBMISSION    │
+│ Integrations  │ Pitch/Video   │               │
+└───────────────┴───────────────┴───────────────┘
+```
+
+---
+
+## What We're NOT Doing
+
+- ❌ Mobile app (web first)
+- ❌ Multi-user (personal tool first)
+- ❌ Team features (solo first)
+- ❌ Manual entry (pull only)
+- ❌ Another methodology (zero setup)
+
+---
+
+## The Focus
+
+**MVP → Demo → Submit → Iterate**
+
+Get it working. Get it to judges. Get feedback. Build more.
+
+*"We got no users so no need to worry about old things"* — Ash-Blanc

--- a/src/order/api.py
+++ b/src/order/api.py
@@ -13,6 +13,13 @@ from .modes.reduce import reduce_mode
 from .modes.conversation import conversation
 from .modes.just_in_time import just_in_time
 from .modes.executor import executor
+from .cron.scheduler import CronScheduler
+from .cron import jobs as cron_jobs
+
+scheduler = CronScheduler()
+scheduler.register("gather", cron_jobs.gather_all)
+scheduler.register("reduce", cron_jobs.reduce_all)
+scheduler.register("expire", cron_jobs.expire_old)
 
 
 @asynccontextmanager
@@ -24,6 +31,7 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         print(f"DB init error: {e}")
     
+    scheduler.run_in_background()
     yield
 
 
@@ -205,6 +213,25 @@ async def execute_action(commitment_id: str, action: str):
     """Execute action on commitment"""
     commitment = await executor.commit(commitment_id, action)
     return commitment.model_dump()
+
+
+# ============== CRON ==============
+
+@app.get("/api/cron/status")
+async def cron_status():
+    """Get last-run timestamps for all cron jobs"""
+    return scheduler.get_status()
+
+
+@app.post("/api/cron/trigger/{job_name}")
+async def trigger_job(job_name: str):
+    """Manually trigger a cron job (gather | reduce | expire)"""
+    if job_name not in ("gather", "reduce", "expire"):
+        raise HTTPException(400, f"Unknown job: {job_name}. Use gather, reduce, or expire.")
+    ran = await scheduler.run_job_now(job_name)
+    if not ran:
+        raise HTTPException(404, f"Job '{job_name}' not registered")
+    return {"status": "triggered", "job": job_name}
 
 
 # ============== HEALTH ==============

--- a/src/order/cron/scheduler.py
+++ b/src/order/cron/scheduler.py
@@ -1,7 +1,7 @@
 """Hermes-style file-based cron scheduler"""
 import asyncio
-import fcntl
 import json
+import sys
 from pathlib import Path
 from datetime import datetime, timedelta
 from typing import Callable, Awaitable
@@ -9,9 +9,40 @@ from typing import Callable, Awaitable
 from ..core.config import settings
 
 
+def _try_lock(f) -> bool:
+    """Attempt to acquire an exclusive non-blocking file lock. Returns True on success."""
+    if sys.platform == "win32":
+        import msvcrt
+        try:
+            msvcrt.locking(f.fileno(), msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+    else:
+        import fcntl
+        try:
+            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except BlockingIOError:
+            return False
+
+
+def _unlock(f):
+    """Release file lock."""
+    if sys.platform == "win32":
+        import msvcrt
+        try:
+            msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+    else:
+        import fcntl
+        fcntl.flock(f, fcntl.LOCK_UN)
+
+
 class CronScheduler:
     """File-based cron scheduler with tick-based execution"""
-    
+
     def __init__(
         self,
         tick_interval: int = 60,
@@ -21,96 +52,113 @@ class CronScheduler:
         self.data_dir = Path(data_dir or settings.data_dir)
         self.lock_file = self.data_dir / "cron" / ".tick.lock"
         self.state_file = self.data_dir / "cron" / "state.json"
-        
+
         # Jobs registry
         self.jobs: dict[str, Callable[[], Awaitable]] = {}
-        
+
         # Ensure directories exist
         self.lock_file.parent.mkdir(parents=True, exist_ok=True)
-    
+
     def register(self, name: str, job: Callable[[], Awaitable]):
         """Register a job"""
         self.jobs[name] = job
-    
+
     async def tick(self):
         """Called every tick_interval seconds"""
-        # File locking to prevent concurrent ticks
         try:
             with open(self.lock_file, "w") as f:
-                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                if not _try_lock(f):
+                    # Another process is running
+                    return
                 try:
                     await self._run_jobs()
                 finally:
-                    fcntl.flock(f, fcntl.LOCK_UN)
-        except BlockingIOError:
-            # Another process is running
+                    _unlock(f)
+        except OSError:
             pass
-    
+
+    async def run_job_now(self, job_name: str) -> bool:
+        """Manually trigger a specific job by name. Returns True if job was found and run."""
+        if job_name not in self.jobs:
+            return False
+        await self.jobs[job_name]()
+        state = self._load_state()
+        state[f"last_{job_name}"] = datetime.now().isoformat()
+        self._save_state(state)
+        return True
+
+    def get_status(self) -> dict:
+        """Return last-run timestamps for all registered jobs."""
+        state = self._load_state()
+        return {
+            name: state.get(f"last_{name}") for name in self.jobs
+        }
+
     async def _run_jobs(self):
         """Run scheduled jobs"""
         state = self._load_state()
         now = datetime.now()
-        
+
         # Gather job - every X minutes
         if self._should_run(state, "gather", minutes=settings.gather_interval_minutes):
             if "gather" in self.jobs:
                 await self.jobs["gather"]()
             state["last_gather"] = now.isoformat()
-        
+
         # Reduce job - every X minutes
         if self._should_run(state, "reduce", minutes=settings.reduce_interval_minutes):
             if "reduce" in self.jobs:
                 await self.jobs["reduce"]()
             state["last_reduce"] = now.isoformat()
-        
+
         # Expire job - every X hours
         if self._should_run(state, "expire", hours=settings.expire_interval_hours):
             if "expire" in self.jobs:
                 await self.jobs["expire"]()
             state["last_expire"] = now.isoformat()
-        
+
         self._save_state(state)
-    
+
     def _should_run(
-        self, 
-        state: dict, 
-        job_name: str, 
-        minutes: int = 0, 
+        self,
+        state: dict,
+        job_name: str,
+        minutes: int = 0,
         hours: int = 0
     ) -> bool:
         """Check if job should run based on last run time"""
         key = f"last_{job_name}"
         last_run = state.get(key)
-        
+
         if not last_run:
             return True
-        
+
         try:
             last = datetime.fromisoformat(last_run)
             interval = timedelta(minutes=minutes, hours=hours)
             return datetime.now() - last >= interval
-        except:
+        except Exception:
             return True
-    
+
     def _load_state(self) -> dict:
         """Load scheduler state"""
         if self.state_file.exists():
             try:
                 return json.loads(self.state_file.read_text())
-            except:
+            except Exception:
                 pass
         return {}
-    
+
     def _save_state(self, state: dict):
         """Save scheduler state"""
         self.state_file.write_text(json.dumps(state, indent=2))
-    
+
     async def run_forever(self):
         """Run scheduler in a loop"""
         while True:
             await self.tick()
             await asyncio.sleep(self.tick_interval)
-    
+
     def run_in_background(self):
         """Start scheduler in background"""
         asyncio.create_task(self.run_forever())


### PR DESCRIPTION
## Summary
- `fcntl` is Linux-only — the scheduler crashed immediately on macOS/Windows with `ModuleNotFoundError`
- Added `GET /api/cron/status` and `POST /api/cron/trigger/{job_name}` so the demo can manually trigger jobs without waiting for the interval

## Changes
- `src/order/cron/scheduler.py`: replace bare `fcntl` with a `_try_lock`/`_unlock` helper that uses `msvcrt` on Windows, `fcntl` on Unix
- `src/order/cron/scheduler.py`: add `run_job_now(name)` and `get_status()` methods
- `src/order/api.py`: wire scheduler into FastAPI lifespan + add `/api/cron/status` and `/api/cron/trigger/{job_name}` endpoints

## Test plan
- [ ] Run server on Windows — confirm no `ModuleNotFoundError` on startup
- [ ] `POST /api/cron/trigger/gather` → returns `{"status":"triggered","job":"gather"}`
- [ ] `GET /api/cron/status` → shows timestamps for gather/reduce/expire

Closes #12