### PR TITLE
fix: restrict CORS, add rate limiting, validate user inputs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,194 @@
+# Architecture
+
+## System Overview
+
+Order is an agentic life order system that gathers scattered commitments from multiple sources and surfaces them through different interaction modes.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Frontend                              │
+│                    (Next.js + Tailwind)                      │
+│   ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐     │
+│   │Drown │ │Scatt │ │Stuck │ │Accum │ │Spec  │ │Ready │     │
+│   └──┬───┘ └──┬───┘ └──┬───┘ └──┬───┘ └──┬───┘ └──┬───┘     │
+│      │        │        │        │        │        │          │
+│   ┌──┴────────┴────────┴────────┴────────┴────────┴───┐     │
+│   │              Mode Selector                         │     │
+│   └────────────────────┬──────────────────────────────┘     │
+└────────────────────────┼─────────────────────────────────────┘
+                         │ HTTP/SSE
+┌────────────────────────┼─────────────────────────────────────┐
+│                        │ Backend                             │
+│                        ▼                                     │
+│   ┌─────────────────────────────────────────────────────┐   │
+│   │                   FastAPI                            │   │
+│   │  /api/one-thing  /api/gather  /api/chat  ...       │   │
+│   └────────────────────┬────────────────────────────────┘   │
+│                        │                                     │
+│   ┌────────────────────┼────────────────────────────────┐   │
+│   │                    ▼                                 │   │
+│   │   ┌──────────┐  ┌──────────┐  ┌──────────┐          │   │
+│   │   │  Modes   │  │ Synthesis│  │   Cron   │          │   │
+│   │   │  (6)     │  │  (LLM)   │  │ Scheduler│          │   │
+│   │   └────┬─────┘  └────┬─────┘  └────┬─────┘          │   │
+│   │        │             │             │                 │   │
+│   │        └─────────────┼─────────────┘                 │   │
+│   │                      ▼                               │   │
+│   │            ┌──────────────────┐                      │   │
+│   │            │  SQLite Store    │                      │   │
+│   │            │  (async)         │                      │   │
+│   │            └──────────────────┘                      │   │
+│   └──────────────────────────────────────────────────────┘   │
+│                        │                                     │
+│   ┌────────────────────┼────────────────────────────────┐   │
+│   │                    ▼      Gatherers                   │   │
+│   │   ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐   │   │
+│   │   │ Discord │ │ GitHub  │ │    X    │ │  Gmail  │   │   │
+│   │   │TinyFish │ │API      │ │TinyFish │ │TinyFish │   │   │
+│   │   └────┬────┘ └────┬────┘ └────┬────┘ └────┬────┘   │   │
+│   └────────┼───────────┼───────────┼───────────┼─────────┘   │
+└────────────┼───────────┼───────────┼───────────┼─────────────┘
+             │           │           │           │
+         ┌───┴───┐   ┌───┴───┐   ┌───┴───┐   ┌───┴───┐
+         │Discord│   │GitHub │   │   X   │   │ Gmail │
+         └───────┘   └───────┘   └───────┘   └───────┘
+```
+
+## Core Components
+
+### 1. Gatherers
+Collect commitments from external sources.
+
+| Source | Method | When |
+|--------|--------|------|
+| Discord | TinyFish SSE | No API for message search |
+| GitHub | REST API | Issues assigned, PRs awaiting review |
+| X (Twitter) | TinyFish SSE | DMs, bookmarks |
+| Gmail | TinyFish SSE | Actionable emails |
+
+**Base Pattern**:
+```python
+class BaseGatherer(ABC):
+    @abstractmethod
+    async def gather(self) -> AsyncIterator[Commitment]: ...
+    
+    async def run(self) -> GatherResult:
+        # Collect all commitments, return result
+```
+
+### 2. SQLite Store
+Async persistence with SQLAlchemy ORM.
+
+```python
+class CommitmentRow(Base):
+    id: str              # UUID
+    source: str          # discord, github, x_dm, x_bookmark, gmail
+    text: str            # Original message
+    extracted_task: str  # AI-extracted task
+    deadline: datetime   # Optional
+    priority: int        # 0-3
+    status: str          # pending, done, ignored, expired
+    raw_data: JSON       # Full original data
+```
+
+### 3. AI Synthesis
+LiteLLM-based filtering and prioritization.
+
+```python
+async def extract_commitment(text, source) -> dict
+async def filter_commitments(commitments) -> List[Commitment]
+async def prioritize_commitments(commitments) -> List[Commitment]
+async def pick_one_thing(commitments) -> Commitment
+```
+
+**Fallback**: Works without LLM API key (simple priority sorting).
+
+### 4. Cron Scheduler
+Hermes-style file-based scheduler with tick pattern.
+
+```python
+class CronScheduler:
+    def register(name, job_func)
+    def run_in_background()
+    # Uses fcntl for file locking
+    # Tick every 60 seconds
+```
+
+**Jobs**:
+- `gather_all` (every 5 min)
+- `reduce_all` (every 10 min)
+- `expire_old` (every hour)
+
+### 5. Modes
+Six interaction modes for different mental states.
+
+| Mode | State | Behavior |
+|------|-------|----------|
+| One-Thing | Drowning | Show only ONE commitment |
+| Gather | Scattered | Pull from all sources |
+| Reduce | Accumulated | Filter noise, keep what matters |
+| Conversation | Stuck | Thinking partner chat |
+| Just-in-Time | Specific | Ask and receive, no storage |
+| Executor | Ready | Agents handle tasks |
+
+## Data Flow
+
+```
+1. User connects accounts (Discord, GitHub, X, Gmail)
+2. Cron jobs gather commitments periodically
+3. AI synthesis filters and prioritizes
+4. Modes surface based on user's state
+5. User acts (done, skip, delegate)
+6. Status updates reflect in stats
+```
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|------------|
+| Frontend | Next.js 16, Tailwind, Bun |
+| Backend | FastAPI, uvicorn |
+| Storage | SQLite (async) + SQLAlchemy |
+| AI | LiteLLM (any provider) |
+| Scraping | TinyFish (authenticated browser) |
+| Cron | Hermes-style file-based |
+| Runtime | Python 3.13, uv |
+
+## Key Design Decisions
+
+### Why TinyFish?
+Discord and X have no APIs for message search. TinyFish provides authenticated browser automation via SSE streaming.
+
+### Why SQLite?
+Simple, async, no server needed. Perfect for personal tool.
+
+### Why 6 Modes?
+Different chaos states need different interactions. One-size-fits-all doesn't work.
+
+### Why Fallback Mode?
+Production should work without LLM. Simple priority sorting is better than nothing.
+
+## File Structure
+
+```
+order/
+├── src/order/
+│   ├── core/           # Models, config, store
+│   ├── gatherers/      # TinyFish + API gatherers
+│   ├── synthesis/      # LLM integration
+│   ├── modes/          # 6 interaction modes
+│   ├── cron/           # Background jobs
+│   └── api.py          # FastAPI endpoints
+│
+└── frontend/
+    ├── app/            # Next.js pages
+    ├── components/     # Mode views
+    └── lib/            # API client
+```
+
+## Security Considerations
+
+- API keys stored in environment variables
+- No user data stored permanently (commitments expire)
+- TinyFish handles authentication (no credentials stored)
+- Fallback mode works without external APIs

--- a/docs/manifesto.md
+++ b/docs/manifesto.md
@@ -1,0 +1,141 @@
+# Order Manifesto
+
+## The Problem
+
+Your commitments are scattered. Discord messages, GitHub issues, X DMs, emails—each holds a piece of what you promised to do. 
+
+You tried Notion. You tried Obsidian. You tried every todo app.
+
+They all failed for the same reason: **they require you to do the work**.
+
+- Open the app
+- Write down what you need to do
+- Organize it
+- Check it later
+- Feel guilty when you don't
+
+This is **productivity theater**. It's not solving the problem—it's creating new work.
+
+## The Real Problem
+
+In the AI era, the problem isn't organization. It's:
+
+1. **Context Collapse** - Your commitments live in 10 different places
+2. **Information Bankruptcy** - You can't remember what you promised
+3. **Attention Fragmentation** - Every tool demands its own context
+4. **Cognitive Overload** - More tools = more mental load
+
+The average knowledge worker has **commitments scattered across 5+ platforms**. Each one invisible to the others.
+
+You don't need a better tool. You need **something that finds what you already said you'd do**.
+
+## The Solution
+
+**Order** doesn't ask you to organize. It finds what you already promised.
+
+### Core Principles
+
+1. **Zero Setup** - Connect accounts, done. No methodology to learn.
+2. **Pull, Don't Push** - We find your commitments. You don't enter them.
+3. **Multiple Paths** - Different chaos states need different interactions.
+4. **Radical Simplicity** - One-Thing mode shows only ONE commitment.
+5. **Always Fresh** - Background jobs keep it updated automatically.
+6. **Agentic** - Not just tracking. Agents can handle tasks.
+
+### Why 6 Modes?
+
+Because chaos isn't one-dimensional.
+
+| State | What You Feel | What You Need |
+|-------|---------------|---------------|
+| Drowning | "I can't think" | ONE thing |
+| Scattered | "I don't know what I promised" | Gather all |
+| Stuck | "I know but I can't start" | Thinking partner |
+| Accumulated | "Too much on my plate" | Filter noise |
+| Specific | "What about X?" | Just-in-time answer |
+| Ready | "Let's do this" | Execute |
+
+One-size-fits-all doesn't work. You need different tools for different states.
+
+### Why TinyFish?
+
+Discord and X don't have APIs for message search. But that's where your commitments live.
+
+TinyFish provides authenticated browser automation. We can:
+- Search Discord messages for promises
+- Find X DMs and bookmarks
+- Process Gmail for actionable emails
+
+No manual entry. No copying. Just connect and done.
+
+## The Anti-Productivity Product
+
+Order is the **anti-Notion**.
+
+| Notion | Order |
+|--------|-------|
+| Manual entry | Automatic gathering |
+| Single workspace | Multi-source sync |
+| You organize | AI filters |
+| Learning curve | Zero setup |
+| More tools | Less tools |
+| Productivity theater | Pull your actual commitments |
+
+## The Philosophy
+
+### 1. Life is Chaos
+Stop pretending you'll organize it. You won't. We know.
+
+### 2. Commitments are Scattered
+They live where you made them. Go find them there.
+
+### 3. One Thing at a Time
+When drowning, you don't need 100 commitments. You need ONE.
+
+### 4. Context is Everything
+Different states need different tools. Match the tool to the state.
+
+### 5. Less is More
+No features you won't use. No setup you'll skip. No learning curve.
+
+## The Vision
+
+**Order** brings order to chaos without requiring you to change.
+
+- Connect your accounts once
+- Background jobs keep it fresh
+- AI surfaces what matters
+- You act when ready
+
+No manual entry. No organization. No guilt.
+
+**Just order from chaos.**
+
+---
+
+## For the Hackathon
+
+This is a TinyFish-powered demo for the HackerEarth pre-accelerator.
+
+**What we're building:**
+- TinyFish gatherers for Discord, X, Gmail
+- GitHub API for issues/PRs
+- 6 interaction modes
+- AI synthesis with LiteLLM
+- Background cron jobs
+
+**What we're proving:**
+- Pulling commitments from scattered sources works
+- Multiple modes for different chaos states is valuable
+- Zero-setup productivity is possible
+
+**What we're NOT building:**
+- Another Notion
+- Another todo app
+- Another productivity methodology
+
+**We're building** the thing that finds what you already promised.
+
+---
+
+*Order brings order to chaos. Not by adding more tools, but by finding what's already there.*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,203 @@
+# Roadmap
+
+## TinyFish Hackathon Sprint
+
+**Goal**: Demo-ready for HackerEarth pre-accelerator submission
+
+**Timeline**: 2-3 weeks
+
+---
+
+## Phase 1: MVP Foundation (Week 1)
+
+### Goal
+Get core functionality working end-to-end.
+
+### Tasks
+- [ ] Backend runs without errors
+- [ ] Frontend connects to backend
+- [ ] One-Thing mode works
+- [ ] Gather mode shows mock data
+- [ ] Basic error handling
+- [ ] README with setup instructions
+
+### Acceptance Criteria
+- `uv run uvicorn order.api:app` starts server
+- `bun run dev` shows frontend
+- Clicking through modes doesn't crash
+- At least one commitment shows in One-Thing
+
+### GitHub Issues
+- #1 MVP Demo Ready
+- #11 6 Modes End-to-End Testing
+
+---
+
+## Phase 2: Integrations + AI (Week 1-2)
+
+### Goal
+Real data flowing from sources, AI working.
+
+### Tasks
+- [ ] TinyFish API key configuration
+- [ ] Discord gatherer with real account
+- [ ] X (Twitter) gatherer with real account
+- [ ] GitHub gatherer with real PAT
+- [ ] Gmail gatherer with real account
+- [ ] Test AI synthesis quality
+- [ ] Add fallback mode
+
+### Acceptance Criteria
+- All 4 sources show as connected
+- Gather pulls real commitments
+- AI filters noise correctly
+- Works without LLM API key
+
+### GitHub Issues
+- #2 Source Integrations
+- #10 AI Synthesis Quality
+
+---
+
+## Phase 3: Polish + Pitch (Week 2)
+
+### Goal
+Production-ready for demo, compelling pitch.
+
+### Tasks
+- [ ] Improve mode selector UX
+- [ ] Add loading states
+- [ ] Add animations/transitions
+- [ ] Error states with retry
+- [ ] Empty states
+- [ ] Source icons
+- [ ] Deadline indicators
+- [ ] Create pitch deck (8-10 slides)
+- [ ] Record demo video (60-90s)
+
+### Acceptance Criteria
+- Feels like a polished product
+- Pitch deck ready
+- Demo video uploaded
+
+### GitHub Issues
+- #3 Frontend Polish
+- #4 Pitch Deck
+- #5 Demo Video
+
+---
+
+## Phase 4: Deployment (Week 2-3)
+
+### Goal
+Live demo URL for judges.
+
+### Tasks
+- [ ] Deploy backend to Railway/Fly.io
+- [ ] Deploy frontend to Vercel
+- [ ] Set environment variables
+- [ ] Test all endpoints
+- [ ] Add deployment badges
+
+### Acceptance Criteria
+- Live URL works
+- All API endpoints accessible
+- Frontend connects to backend
+
+### GitHub Issues
+- #6 Deployment
+
+---
+
+## Hackathon Submission Checklist
+
+- [ ] Working demo (live URL or video)
+- [ ] Pitch deck (PDF)
+- [ ] Demo video (60-90s)
+- [ ] Code repository (public)
+- [ ] README with setup
+- [ ] TinyFish integration prominent
+
+---
+
+## Post-Hackathon Roadmap
+
+### Phase 5: Production Ready
+- Rate limiting
+- Input validation
+- Proper CORS
+- Error logging
+- Health monitoring
+- **Issue #7 Security**
+
+### Phase 6: Quality of Life
+- Email digests
+- Mobile responsive polish
+- Keyboard shortcuts
+- Better error messages
+- **Issue #8 Email Digest**
+
+### Phase 7: Scale
+- Multi-user support
+- Team workspaces
+- Shared commitments
+- Integrations (Slack, Teams)
+- Webhooks
+
+### Phase 8: Intelligence
+- Better AI extraction
+- Deadline prediction
+- Commitment patterns
+- Smart reminders
+- Priority learning
+
+---
+
+## Success Metrics
+
+### Hackathon
+- ✅ Demo works live
+- ✅ Pitch deck compelling
+- ✅ TinyFish integration shown
+- ✅ All 6 modes functional
+
+### Post-Hackathon
+- Real users actually using it
+- Commitments gathered per week
+- Time saved vs manual organization
+- User retention
+
+---
+
+## Timeline Visualization
+
+```
+Week 1          Week 2          Week 3
+├───────────────┼───────────────┼───────────────┤
+│ Phase 1       │ Phase 3       │ Phase 4       │
+│ MVP           │ Polish        │ Deploy        │
+│               │               │               │
+│ Phase 2       │ Phase 3       │ SUBMISSION    │
+│ Integrations  │ Pitch/Video   │               │
+└───────────────┴───────────────┴───────────────┘
+```
+
+---
+
+## What We're NOT Doing
+
+- ❌ Mobile app (web first)
+- ❌ Multi-user (personal tool first)
+- ❌ Team features (solo first)
+- ❌ Manual entry (pull only)
+- ❌ Another methodology (zero setup)
+
+---
+
+## The Focus
+
+**MVP → Demo → Submit → Iterate**
+
+Get it working. Get it to judges. Get feedback. Build more.
+
+*"We got no users so no need to worry about old things"* — Ash-Blanc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "python-dotenv>=1.2.2",
     "sqlalchemy>=2.0.48",
     "uvicorn>=0.42.0",
+    "slowapi>=0.1.9",
 ]
 
 [project.scripts]

--- a/src/order/api.py
+++ b/src/order/api.py
@@ -1,11 +1,17 @@
 """FastAPI endpoints"""
+import logging
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, field_validator
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
 
 from .core.store import store
+from .core.config import settings
 from .core.models import Commitment, CommitmentStatus, Source
 from .modes.one_thing import one_thing
 from .modes.gather import gather
@@ -14,16 +20,19 @@ from .modes.conversation import conversation
 from .modes.just_in_time import just_in_time
 from .modes.executor import executor
 
+logger = logging.getLogger(__name__)
+
+limiter = Limiter(key_func=get_remote_address, default_limits=["60/minute"])
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup and shutdown"""
-    # Initialize database
     try:
         await store.init_db()
     except Exception as e:
-        print(f"DB init error: {e}")
-    
+        logger.error("DB init error: %s", e)
+
     yield
 
 
@@ -34,13 +43,20 @@ app = FastAPI(
     lifespan=lifespan
 )
 
-# CORS
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+# CORS — allow localhost dev origins and the configured frontend URL
+_cors_origins = ["http://localhost:3000", "http://127.0.0.1:3000"]
+if getattr(settings, "frontend_url", None):
+    _cors_origins.append(settings.frontend_url)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST"],
+    allow_headers=["Content-Type", "Authorization"],
 )
 
 
@@ -128,6 +144,16 @@ async def get_stats():
 class ChatRequest(BaseModel):
     message: str
 
+    @field_validator("message")
+    @classmethod
+    def message_not_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("message must not be empty")
+        if len(v) > 2000:
+            raise ValueError("message must be 2000 characters or fewer")
+        return v
+
 
 @app.post("/api/chat")
 async def chat(req: ChatRequest):
@@ -147,6 +173,16 @@ async def reset_chat():
 
 class SearchRequest(BaseModel):
     query: str
+
+    @field_validator("query")
+    @classmethod
+    def query_not_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("query must not be empty")
+        if len(v) > 500:
+            raise ValueError("query must be 500 characters or fewer")
+        return v
 
 
 @app.post("/api/search")

--- a/src/order/core/config.py
+++ b/src/order/core/config.py
@@ -9,6 +9,9 @@ class Settings(BaseSettings):
     github_token: str = ""
     openai_api_key: str = ""
     openrouter_api_key: str = ""
+
+    # CORS — set to your deployed frontend URL in production
+    frontend_url: str = ""
     
     # Model config
     llm_model: str = "openrouter/nova-pro"


### PR DESCRIPTION
## Summary
- CORS `allow_origins=["*"]` exposes the API to any website — replaced with explicit origins
- No rate limiting meant any client could spam LLM-backed endpoints
- Chat and search inputs had no length bounds — unbounded strings forwarded to the LLM

## Changes
- `src/order/api.py`: CORS now allows only `localhost:3000` + optional `ORDER_FRONTEND_URL`; methods/headers scoped to what's needed
- `src/order/api.py`: add `slowapi` with 60 req/min default limit per IP
- `src/order/api.py`: add `@field_validator` on `ChatRequest.message` (≤2000 chars) and `SearchRequest.query` (≤500 chars)
- `src/order/api.py`: replace `print()` with `logging.getLogger`
- `src/order/core/config.py`: add `ORDER_FRONTEND_URL` setting
- `pyproject.toml`: add `slowapi>=0.1.9`

## Test plan
- [ ] Frontend at `localhost:3000` can still call all API endpoints
- [ ] A request from a different origin is rejected with CORS error
- [ ] Sending > 60 requests/min returns HTTP 429
- [ ] POST `/api/chat` with empty string returns HTTP 422

Closes #7