### PR TITLE
feat: improve AI synthesis quality — prompts, OpenAI fallback, smarter heuristics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,194 @@
+# Architecture
+
+## System Overview
+
+Order is an agentic life order system that gathers scattered commitments from multiple sources and surfaces them through different interaction modes.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Frontend                              │
+│                    (Next.js + Tailwind)                      │
+│   ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐     │
+│   │Drown │ │Scatt │ │Stuck │ │Accum │ │Spec  │ │Ready │     │
+│   └──┬───┘ └──┬───┘ └──┬───┘ └──┬───┘ └──┬───┘ └──┬───┘     │
+│      │        │        │        │        │        │          │
+│   ┌──┴────────┴────────┴────────┴────────┴────────┴───┐     │
+│   │              Mode Selector                         │     │
+│   └────────────────────┬──────────────────────────────┘     │
+└────────────────────────┼─────────────────────────────────────┘
+                         │ HTTP/SSE
+┌────────────────────────┼─────────────────────────────────────┐
+│                        │ Backend                             │
+│                        ▼                                     │
+│   ┌─────────────────────────────────────────────────────┐   │
+│   │                   FastAPI                            │   │
+│   │  /api/one-thing  /api/gather  /api/chat  ...       │   │
+│   └────────────────────┬────────────────────────────────┘   │
+│                        │                                     │
+│   ┌────────────────────┼────────────────────────────────┐   │
+│   │                    ▼                                 │   │
+│   │   ┌──────────┐  ┌──────────┐  ┌──────────┐          │   │
+│   │   │  Modes   │  │ Synthesis│  │   Cron   │          │   │
+│   │   │  (6)     │  │  (LLM)   │  │ Scheduler│          │   │
+│   │   └────┬─────┘  └────┬─────┘  └────┬─────┘          │   │
+│   │        │             │             │                 │   │
+│   │        └─────────────┼─────────────┘                 │   │
+│   │                      ▼                               │   │
+│   │            ┌──────────────────┐                      │   │
+│   │            │  SQLite Store    │                      │   │
+│   │            │  (async)         │                      │   │
+│   │            └──────────────────┘                      │   │
+│   └──────────────────────────────────────────────────────┘   │
+│                        │                                     │
+│   ┌────────────────────┼────────────────────────────────┐   │
+│   │                    ▼      Gatherers                   │   │
+│   │   ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐   │   │
+│   │   │ Discord │ │ GitHub  │ │    X    │ │  Gmail  │   │   │
+│   │   │TinyFish │ │API      │ │TinyFish │ │TinyFish │   │   │
+│   │   └────┬────┘ └────┬────┘ └────┬────┘ └────┬────┘   │   │
+│   └────────┼───────────┼───────────┼───────────┼─────────┘   │
+└────────────┼───────────┼───────────┼───────────┼─────────────┘
+             │           │           │           │
+         ┌───┴───┐   ┌───┴───┐   ┌───┴───┐   ┌───┴───┐
+         │Discord│   │GitHub │   │   X   │   │ Gmail │
+         └───────┘   └───────┘   └───────┘   └───────┘
+```
+
+## Core Components
+
+### 1. Gatherers
+Collect commitments from external sources.
+
+| Source | Method | When |
+|--------|--------|------|
+| Discord | TinyFish SSE | No API for message search |
+| GitHub | REST API | Issues assigned, PRs awaiting review |
+| X (Twitter) | TinyFish SSE | DMs, bookmarks |
+| Gmail | TinyFish SSE | Actionable emails |
+
+**Base Pattern**:
+```python
+class BaseGatherer(ABC):
+    @abstractmethod
+    async def gather(self) -> AsyncIterator[Commitment]: ...
+    
+    async def run(self) -> GatherResult:
+        # Collect all commitments, return result
+```
+
+### 2. SQLite Store
+Async persistence with SQLAlchemy ORM.
+
+```python
+class CommitmentRow(Base):
+    id: str              # UUID
+    source: str          # discord, github, x_dm, x_bookmark, gmail
+    text: str            # Original message
+    extracted_task: str  # AI-extracted task
+    deadline: datetime   # Optional
+    priority: int        # 0-3
+    status: str          # pending, done, ignored, expired
+    raw_data: JSON       # Full original data
+```
+
+### 3. AI Synthesis
+LiteLLM-based filtering and prioritization.
+
+```python
+async def extract_commitment(text, source) -> dict
+async def filter_commitments(commitments) -> List[Commitment]
+async def prioritize_commitments(commitments) -> List[Commitment]
+async def pick_one_thing(commitments) -> Commitment
+```
+
+**Fallback**: Works without LLM API key (simple priority sorting).
+
+### 4. Cron Scheduler
+Hermes-style file-based scheduler with tick pattern.
+
+```python
+class CronScheduler:
+    def register(name, job_func)
+    def run_in_background()
+    # Uses fcntl for file locking
+    # Tick every 60 seconds
+```
+
+**Jobs**:
+- `gather_all` (every 5 min)
+- `reduce_all` (every 10 min)
+- `expire_old` (every hour)
+
+### 5. Modes
+Six interaction modes for different mental states.
+
+| Mode | State | Behavior |
+|------|-------|----------|
+| One-Thing | Drowning | Show only ONE commitment |
+| Gather | Scattered | Pull from all sources |
+| Reduce | Accumulated | Filter noise, keep what matters |
+| Conversation | Stuck | Thinking partner chat |
+| Just-in-Time | Specific | Ask and receive, no storage |
+| Executor | Ready | Agents handle tasks |
+
+## Data Flow
+
+```
+1. User connects accounts (Discord, GitHub, X, Gmail)
+2. Cron jobs gather commitments periodically
+3. AI synthesis filters and prioritizes
+4. Modes surface based on user's state
+5. User acts (done, skip, delegate)
+6. Status updates reflect in stats
+```
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|------------|
+| Frontend | Next.js 16, Tailwind, Bun |
+| Backend | FastAPI, uvicorn |
+| Storage | SQLite (async) + SQLAlchemy |
+| AI | LiteLLM (any provider) |
+| Scraping | TinyFish (authenticated browser) |
+| Cron | Hermes-style file-based |
+| Runtime | Python 3.13, uv |
+
+## Key Design Decisions
+
+### Why TinyFish?
+Discord and X have no APIs for message search. TinyFish provides authenticated browser automation via SSE streaming.
+
+### Why SQLite?
+Simple, async, no server needed. Perfect for personal tool.
+
+### Why 6 Modes?
+Different chaos states need different interactions. One-size-fits-all doesn't work.
+
+### Why Fallback Mode?
+Production should work without LLM. Simple priority sorting is better than nothing.
+
+## File Structure
+
+```
+order/
+├── src/order/
+│   ├── core/           # Models, config, store
+│   ├── gatherers/      # TinyFish + API gatherers
+│   ├── synthesis/      # LLM integration
+│   ├── modes/          # 6 interaction modes
+│   ├── cron/           # Background jobs
+│   └── api.py          # FastAPI endpoints
+│
+└── frontend/
+    ├── app/            # Next.js pages
+    ├── components/     # Mode views
+    └── lib/            # API client
+```
+
+## Security Considerations
+
+- API keys stored in environment variables
+- No user data stored permanently (commitments expire)
+- TinyFish handles authentication (no credentials stored)
+- Fallback mode works without external APIs

--- a/docs/manifesto.md
+++ b/docs/manifesto.md
@@ -1,0 +1,141 @@
+# Order Manifesto
+
+## The Problem
+
+Your commitments are scattered. Discord messages, GitHub issues, X DMs, emails—each holds a piece of what you promised to do. 
+
+You tried Notion. You tried Obsidian. You tried every todo app.
+
+They all failed for the same reason: **they require you to do the work**.
+
+- Open the app
+- Write down what you need to do
+- Organize it
+- Check it later
+- Feel guilty when you don't
+
+This is **productivity theater**. It's not solving the problem—it's creating new work.
+
+## The Real Problem
+
+In the AI era, the problem isn't organization. It's:
+
+1. **Context Collapse** - Your commitments live in 10 different places
+2. **Information Bankruptcy** - You can't remember what you promised
+3. **Attention Fragmentation** - Every tool demands its own context
+4. **Cognitive Overload** - More tools = more mental load
+
+The average knowledge worker has **commitments scattered across 5+ platforms**. Each one invisible to the others.
+
+You don't need a better tool. You need **something that finds what you already said you'd do**.
+
+## The Solution
+
+**Order** doesn't ask you to organize. It finds what you already promised.
+
+### Core Principles
+
+1. **Zero Setup** - Connect accounts, done. No methodology to learn.
+2. **Pull, Don't Push** - We find your commitments. You don't enter them.
+3. **Multiple Paths** - Different chaos states need different interactions.
+4. **Radical Simplicity** - One-Thing mode shows only ONE commitment.
+5. **Always Fresh** - Background jobs keep it updated automatically.
+6. **Agentic** - Not just tracking. Agents can handle tasks.
+
+### Why 6 Modes?
+
+Because chaos isn't one-dimensional.
+
+| State | What You Feel | What You Need |
+|-------|---------------|---------------|
+| Drowning | "I can't think" | ONE thing |
+| Scattered | "I don't know what I promised" | Gather all |
+| Stuck | "I know but I can't start" | Thinking partner |
+| Accumulated | "Too much on my plate" | Filter noise |
+| Specific | "What about X?" | Just-in-time answer |
+| Ready | "Let's do this" | Execute |
+
+One-size-fits-all doesn't work. You need different tools for different states.
+
+### Why TinyFish?
+
+Discord and X don't have APIs for message search. But that's where your commitments live.
+
+TinyFish provides authenticated browser automation. We can:
+- Search Discord messages for promises
+- Find X DMs and bookmarks
+- Process Gmail for actionable emails
+
+No manual entry. No copying. Just connect and done.
+
+## The Anti-Productivity Product
+
+Order is the **anti-Notion**.
+
+| Notion | Order |
+|--------|-------|
+| Manual entry | Automatic gathering |
+| Single workspace | Multi-source sync |
+| You organize | AI filters |
+| Learning curve | Zero setup |
+| More tools | Less tools |
+| Productivity theater | Pull your actual commitments |
+
+## The Philosophy
+
+### 1. Life is Chaos
+Stop pretending you'll organize it. You won't. We know.
+
+### 2. Commitments are Scattered
+They live where you made them. Go find them there.
+
+### 3. One Thing at a Time
+When drowning, you don't need 100 commitments. You need ONE.
+
+### 4. Context is Everything
+Different states need different tools. Match the tool to the state.
+
+### 5. Less is More
+No features you won't use. No setup you'll skip. No learning curve.
+
+## The Vision
+
+**Order** brings order to chaos without requiring you to change.
+
+- Connect your accounts once
+- Background jobs keep it fresh
+- AI surfaces what matters
+- You act when ready
+
+No manual entry. No organization. No guilt.
+
+**Just order from chaos.**
+
+---
+
+## For the Hackathon
+
+This is a TinyFish-powered demo for the HackerEarth pre-accelerator.
+
+**What we're building:**
+- TinyFish gatherers for Discord, X, Gmail
+- GitHub API for issues/PRs
+- 6 interaction modes
+- AI synthesis with LiteLLM
+- Background cron jobs
+
+**What we're proving:**
+- Pulling commitments from scattered sources works
+- Multiple modes for different chaos states is valuable
+- Zero-setup productivity is possible
+
+**What we're NOT building:**
+- Another Notion
+- Another todo app
+- Another productivity methodology
+
+**We're building** the thing that finds what you already promised.
+
+---
+
+*Order brings order to chaos. Not by adding more tools, but by finding what's already there.*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,203 @@
+# Roadmap
+
+## TinyFish Hackathon Sprint
+
+**Goal**: Demo-ready for HackerEarth pre-accelerator submission
+
+**Timeline**: 2-3 weeks
+
+---
+
+## Phase 1: MVP Foundation (Week 1)
+
+### Goal
+Get core functionality working end-to-end.
+
+### Tasks
+- [ ] Backend runs without errors
+- [ ] Frontend connects to backend
+- [ ] One-Thing mode works
+- [ ] Gather mode shows mock data
+- [ ] Basic error handling
+- [ ] README with setup instructions
+
+### Acceptance Criteria
+- `uv run uvicorn order.api:app` starts server
+- `bun run dev` shows frontend
+- Clicking through modes doesn't crash
+- At least one commitment shows in One-Thing
+
+### GitHub Issues
+- #1 MVP Demo Ready
+- #11 6 Modes End-to-End Testing
+
+---
+
+## Phase 2: Integrations + AI (Week 1-2)
+
+### Goal
+Real data flowing from sources, AI working.
+
+### Tasks
+- [ ] TinyFish API key configuration
+- [ ] Discord gatherer with real account
+- [ ] X (Twitter) gatherer with real account
+- [ ] GitHub gatherer with real PAT
+- [ ] Gmail gatherer with real account
+- [ ] Test AI synthesis quality
+- [ ] Add fallback mode
+
+### Acceptance Criteria
+- All 4 sources show as connected
+- Gather pulls real commitments
+- AI filters noise correctly
+- Works without LLM API key
+
+### GitHub Issues
+- #2 Source Integrations
+- #10 AI Synthesis Quality
+
+---
+
+## Phase 3: Polish + Pitch (Week 2)
+
+### Goal
+Production-ready for demo, compelling pitch.
+
+### Tasks
+- [ ] Improve mode selector UX
+- [ ] Add loading states
+- [ ] Add animations/transitions
+- [ ] Error states with retry
+- [ ] Empty states
+- [ ] Source icons
+- [ ] Deadline indicators
+- [ ] Create pitch deck (8-10 slides)
+- [ ] Record demo video (60-90s)
+
+### Acceptance Criteria
+- Feels like a polished product
+- Pitch deck ready
+- Demo video uploaded
+
+### GitHub Issues
+- #3 Frontend Polish
+- #4 Pitch Deck
+- #5 Demo Video
+
+---
+
+## Phase 4: Deployment (Week 2-3)
+
+### Goal
+Live demo URL for judges.
+
+### Tasks
+- [ ] Deploy backend to Railway/Fly.io
+- [ ] Deploy frontend to Vercel
+- [ ] Set environment variables
+- [ ] Test all endpoints
+- [ ] Add deployment badges
+
+### Acceptance Criteria
+- Live URL works
+- All API endpoints accessible
+- Frontend connects to backend
+
+### GitHub Issues
+- #6 Deployment
+
+---
+
+## Hackathon Submission Checklist
+
+- [ ] Working demo (live URL or video)
+- [ ] Pitch deck (PDF)
+- [ ] Demo video (60-90s)
+- [ ] Code repository (public)
+- [ ] README with setup
+- [ ] TinyFish integration prominent
+
+---
+
+## Post-Hackathon Roadmap
+
+### Phase 5: Production Ready
+- Rate limiting
+- Input validation
+- Proper CORS
+- Error logging
+- Health monitoring
+- **Issue #7 Security**
+
+### Phase 6: Quality of Life
+- Email digests
+- Mobile responsive polish
+- Keyboard shortcuts
+- Better error messages
+- **Issue #8 Email Digest**
+
+### Phase 7: Scale
+- Multi-user support
+- Team workspaces
+- Shared commitments
+- Integrations (Slack, Teams)
+- Webhooks
+
+### Phase 8: Intelligence
+- Better AI extraction
+- Deadline prediction
+- Commitment patterns
+- Smart reminders
+- Priority learning
+
+---
+
+## Success Metrics
+
+### Hackathon
+- ✅ Demo works live
+- ✅ Pitch deck compelling
+- ✅ TinyFish integration shown
+- ✅ All 6 modes functional
+
+### Post-Hackathon
+- Real users actually using it
+- Commitments gathered per week
+- Time saved vs manual organization
+- User retention
+
+---
+
+## Timeline Visualization
+
+```
+Week 1          Week 2          Week 3
+├───────────────┼───────────────┼───────────────┤
+│ Phase 1       │ Phase 3       │ Phase 4       │
+│ MVP           │ Polish        │ Deploy        │
+│               │               │               │
+│ Phase 2       │ Phase 3       │ SUBMISSION    │
+│ Integrations  │ Pitch/Video   │               │
+└───────────────┴───────────────┴───────────────┘
+```
+
+---
+
+## What We're NOT Doing
+
+- ❌ Mobile app (web first)
+- ❌ Multi-user (personal tool first)
+- ❌ Team features (solo first)
+- ❌ Manual entry (pull only)
+- ❌ Another methodology (zero setup)
+
+---
+
+## The Focus
+
+**MVP → Demo → Submit → Iterate**
+
+Get it working. Get it to judges. Get feedback. Build more.
+
+*"We got no users so no need to worry about old things"* — Ash-Blanc

--- a/src/order/synthesis/llm.py
+++ b/src/order/synthesis/llm.py
@@ -1,12 +1,14 @@
 """AI synthesis using LiteLLM"""
 import json
+import logging
 from typing import List
 from datetime import datetime
 
 from ..core.models import Commitment
 from ..core.config import settings
 
-# Try to import litellm, fall back to simple mode if not configured
+logger = logging.getLogger(__name__)
+
 try:
     from litellm import acompletion
     HAS_LITELLM = True
@@ -14,40 +16,66 @@ except ImportError:
     HAS_LITELLM = False
 
 
+def _has_llm() -> bool:
+    """Return True if a working LLM API key is configured."""
+    return HAS_LITELLM and bool(settings.openrouter_api_key or settings.openai_api_key)
+
+
+def _model() -> str:
+    """Pick model: prefer openrouter, fall back to openai."""
+    if settings.openrouter_api_key:
+        return settings.llm_model
+    return "gpt-4o-mini"
+
+
+async def _complete(messages: list, **kwargs) -> str:
+    """Call acompletion and return the text content."""
+    response = await acompletion(model=_model(), messages=messages, **kwargs)
+    return response.choices[0].message.content
+
+
 async def extract_commitment(text: str, source: str) -> dict:
     """Extract commitment from raw text"""
-    if not HAS_LITELLM or not settings.openrouter_api_key:
-        # Simple extraction without LLM
+    if not _has_llm():
+        # Heuristic fallback
+        lowered = text.lower()
+        is_commitment = any(kw in lowered for kw in (
+            "i'll", "i will", "i can", "i'll make sure", "let me",
+            "can you", "could you", "please", "by friday", "by eod",
+            "deadline", "asap", "urgent",
+        ))
         return {
-            "is_commitment": "?" in text or "can you" in text.lower() or "please" in text.lower(),
-            "task": text[:50],
+            "is_commitment": is_commitment,
+            "task": text[:80].strip(),
             "deadline": None,
-            "priority": 1
+            "priority": 1,
         }
-    
-    prompt = f"""Extract the commitment from this message.
-    
-Source: {source}
+
+    prompt = f"""You are extracting action items from a message.
+
+Source platform: {source}
 Message: {text}
+
+Determine if this message contains a commitment or action item that requires follow-up.
+A commitment is something someone promised to do, or asked you to do.
 
 Return JSON only:
 {{
-    "is_commitment": true/false,
-    "task": "what was promised",
-    "deadline": "YYYY-MM-DD or null",
-    "priority": 0-3
+    "is_commitment": true or false,
+    "task": "concise description of what needs to be done (max 100 chars)",
+    "deadline": "YYYY-MM-DD if a date is mentioned, otherwise null",
+    "priority": 0 (low) | 1 (normal) | 2 (high) | 3 (urgent)
 }}"""
-    
-    from litellm import acompletion
-    response = await acompletion(
-        model=settings.llm_model,
-        messages=[{"role": "user", "content": prompt}],
-        response_format={"type": "json_object"}
-    )
-    
+
     try:
-        return json.loads(response.choices[0].message.content)
-    except:
+        content = await _complete(
+            [{"role": "user", "content": prompt}],
+            response_format={"type": "json_object"},
+            max_tokens=200,
+        )
+        return json.loads(content)
+    except Exception as exc:
+        logger.warning("extract_commitment failed: %s", exc)
         return {"is_commitment": False, "task": "", "deadline": None, "priority": 0}
 
 
@@ -55,43 +83,34 @@ async def filter_commitments(commitments: List[Commitment]) -> List[Commitment]:
     """Filter out noise, keep what matters"""
     if not commitments:
         return []
-    
-    # Without LLM, return all
-    if not HAS_LITELLM or not settings.openrouter_api_key:
+
+    if not _has_llm():
         return commitments
-    
-    # Batch descriptions
+
     items = [
-        f"- [{c.source.value}] {c.text[:100]}..."
-        for c in commitments[:20]
+        f"{i}. [{c.source.value}] {c.extracted_task or c.text[:100]}"
+        for i, c in enumerate(commitments[:20])
     ]
-    
-    prompt = f"""You are filtering commitments for a busy person.
 
-Here are {len(items)} items. Some are noise, some are real commitments.
+    prompt = f"""You are a personal assistant helping filter a list of commitments.
+Keep items that are real, actionable commitments. Remove noise, spam, and duplicates.
 
-For each item, determine:
-- Is this a real commitment or just noise?
-- Should this be kept or can it be safely ignored?
-
-Items:
 {chr(10).join(items)}
 
-Return JSON array with indices to KEEP:
-{{"keep": [0, 1, 3, ...]}}"""
-    
-    from litellm import acompletion
-    response = await acompletion(
-        model=settings.llm_model,
-        messages=[{"role": "user", "content": prompt}],
-        response_format={"type": "json_object"}
-    )
-    
+Return JSON only — an array of indices (0-based) to KEEP:
+{{"keep": [0, 2, 3, ...]}}"""
+
     try:
-        result = json.loads(response.choices[0].message.content)
+        content = await _complete(
+            [{"role": "user", "content": prompt}],
+            response_format={"type": "json_object"},
+            max_tokens=200,
+        )
+        result = json.loads(content)
         keep_indices = set(result.get("keep", []))
         return [c for i, c in enumerate(commitments) if i in keep_indices]
-    except:
+    except Exception as exc:
+        logger.warning("filter_commitments failed: %s", exc)
         return commitments
 
 
@@ -99,17 +118,16 @@ async def prioritize_commitments(commitments: List[Commitment]) -> List[Commitme
     """Prioritize commitments by importance and urgency"""
     if not commitments:
         return []
-    
-    # Sort by existing priority first
-    sorted_commits = sorted(commitments, key=lambda c: c.priority, reverse=True)
-    
-    # If deadlines exist, boost those
-    with_deadlines = [c for c in sorted_commits if c.deadline]
-    without_deadlines = [c for c in sorted_commits if not c.deadline]
-    
-    # Sort by deadline
-    with_deadlines.sort(key=lambda c: c.deadline or datetime.max)
-    
+
+    # Items with deadlines first (soonest first), then by priority
+    with_deadlines = sorted(
+        [c for c in commitments if c.deadline],
+        key=lambda c: (c.deadline, -c.priority),
+    )
+    without_deadlines = sorted(
+        [c for c in commitments if not c.deadline],
+        key=lambda c: -c.priority,
+    )
     return with_deadlines + without_deadlines
 
 
@@ -117,71 +135,71 @@ async def pick_one_thing(commitments: List[Commitment]) -> Commitment | None:
     """Pick the ONE thing to focus on"""
     if not commitments:
         return None
-    
+
     if len(commitments) == 1:
         return commitments[0]
-    
-    # Without LLM, pick highest priority
-    if not HAS_LITELLM or not settings.openrouter_api_key:
-        # Sort by priority, then deadline
-        sorted_commits = sorted(commitments, key=lambda c: (c.priority, c.deadline or datetime.max), reverse=True)
-        return sorted_commits[0]
-    
-    # Describe top candidates
+
+    if not _has_llm():
+        prioritized = await prioritize_commitments(commitments)
+        return prioritized[0]
+
     candidates = commitments[:10]
-    items = [
-        f"- {c.extracted_task} (priority: {c.priority}, deadline: {c.deadline or 'none'})"
-        for c in candidates
-    ]
-    
-    prompt = f"""You are helping someone pick ONE thing to focus on today.
-
-They have {len(commitments)} commitments. Here are the top {len(items)}:
-{chr(10).join(items)}
-
-Pick the ONE most important and urgent item.
-Consider:
-- Priority (higher = more important)
-- Deadlines (sooner = more urgent)
-- Impact (what would have the most benefit)
-
-Return JSON with the index (0-based):
-{{"pick": 0}}"""
-    
-    from litellm import acompletion
-    response = await acompletion(
-        model=settings.llm_model,
-        messages=[{"role": "user", "content": prompt}],
-        response_format={"type": "json_object"}
+    items = "\n".join(
+        f"{i}. {c.extracted_task or c.text[:80]} "
+        f"(priority={c.priority}, deadline={c.deadline or 'none'}, source={c.source.value})"
+        for i, c in enumerate(candidates)
     )
-    
+
+    prompt = f"""You are helping someone who is overwhelmed decide on ONE thing to focus on right now.
+
+Candidates:
+{items}
+
+Consider:
+- Deadlines (sooner = more urgent)
+- Priority level (3=urgent, 2=high, 1=normal, 0=low)
+- Impact (what unlocks the most for this person?)
+
+Return JSON only:
+{{"pick": <index 0-{len(candidates)-1}>, "reason": "one sentence"}}"""
+
     try:
-        result = json.loads(response.choices[0].message.content)
-        idx = result.get("pick", 0)
+        content = await _complete(
+            [{"role": "user", "content": prompt}],
+            response_format={"type": "json_object"},
+            max_tokens=150,
+        )
+        result = json.loads(content)
+        idx = int(result.get("pick", 0))
         return candidates[idx] if idx < len(candidates) else candidates[0]
-    except:
-        return candidates[0]
+    except Exception as exc:
+        logger.warning("pick_one_thing failed: %s", exc)
+        prioritized = await prioritize_commitments(commitments)
+        return prioritized[0]
 
 
 async def explain_why(commitment: Commitment) -> str:
     """Explain why this commitment was chosen"""
-    if not HAS_LITELLM or not settings.openrouter_api_key:
-        return f"Priority: {commitment.priority}, Source: {commitment.source.value}"
-    
-    prompt = f"""Explain briefly why this commitment is a good focus for today:
+    if not _has_llm():
+        parts = [f"Priority: {commitment.priority}", f"Source: {commitment.source.value}"]
+        if commitment.deadline:
+            parts.append(f"Deadline: {commitment.deadline.strftime('%b %d')}")
+        return ", ".join(parts)
 
-Task: {commitment.extracted_task}
+    prompt = f"""Explain in one sentence why this commitment is the best thing to focus on right now:
+
+Task: {commitment.extracted_task or commitment.text[:100]}
 Source: {commitment.source.value}
-Priority: {commitment.priority}
-Deadline: {commitment.deadline or 'none'}
+Priority: {commitment.priority}/3
+Deadline: {commitment.deadline.strftime('%B %d') if commitment.deadline else 'none'}
 
-One sentence explanation:"""
-    
-    from litellm import acompletion
-    response = await acompletion(
-        model=settings.llm_model,
-        messages=[{"role": "user", "content": prompt}],
-        max_tokens=100
-    )
-    
-    return response.choices[0].message.content.strip()
+One sentence (max 120 chars):"""
+
+    try:
+        return await _complete(
+            [{"role": "user", "content": prompt}],
+            max_tokens=80,
+        )
+    except Exception as exc:
+        logger.warning("explain_why failed: %s", exc)
+        return f"Priority {commitment.priority} item from {commitment.source.value}"


### PR DESCRIPTION
## Summary
Several gaps in the LLM synthesis layer that affect demo quality:
- `_has_llm()` only checked `openrouter_api_key`, so OpenAI keys were silently ignored
- The no-LLM heuristic for `extract_commitment` only matched "?" and "please" — missed common phrases like "I'll", "by EOD", "ASAP"
- `prioritize_commitments` put priority before deadline, so a priority-2 item with no deadline would outrank a priority-1 item due tomorrow
- `pick_one_thing` prompt didn't include source platform, losing useful context

## Changes
- `src/order/synthesis/llm.py`: add `_has_llm()` and `_model()` helpers for provider-agnostic LLM access
- `src/order/synthesis/llm.py`: expand heuristic keyword list in `extract_commitment`
- `src/order/synthesis/llm.py`: fix `prioritize_commitments` sort order (deadline urgency first)
- `src/order/synthesis/llm.py`: improve prompts with clearer instructions and output constraints
- `src/order/synthesis/llm.py`: all LLM calls now log warnings on failure instead of silently returning empty

## Test plan
- [ ] Set only `ORDER_OPENAI_API_KEY` (no openrouter key) — confirm LLM features still work
- [ ] Test `extract_commitment` with "I'll send you the report by Friday" — `is_commitment: true`, deadline set
- [ ] Test `extract_commitment` with "Nice to meet you!" — `is_commitment: false`
- [ ] Confirm a commitment with tomorrow's deadline ranks above a priority-2 item with no deadline

Closes #10