### PR TITLE
feat: add e2e and unit tests for all 6 modes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,194 @@
+# Architecture
+
+## System Overview
+
+Order is an agentic life order system that gathers scattered commitments from multiple sources and surfaces them through different interaction modes.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Frontend                              │
+│                    (Next.js + Tailwind)                      │
+│   ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐     │
+│   │Drown │ │Scatt │ │Stuck │ │Accum │ │Spec  │ │Ready │     │
+│   └──┬───┘ └──┬───┘ └──┬───┘ └──┬───┘ └──┬───┘ └──┬───┘     │
+│      │        │        │        │        │        │          │
+│   ┌──┴────────┴────────┴────────┴────────┴────────┴───┐     │
+│   │              Mode Selector                         │     │
+│   └────────────────────┬──────────────────────────────┘     │
+└────────────────────────┼─────────────────────────────────────┘
+                         │ HTTP/SSE
+┌────────────────────────┼─────────────────────────────────────┐
+│                        │ Backend                             │
+│                        ▼                                     │
+│   ┌─────────────────────────────────────────────────────┐   │
+│   │                   FastAPI                            │   │
+│   │  /api/one-thing  /api/gather  /api/chat  ...       │   │
+│   └────────────────────┬────────────────────────────────┘   │
+│                        │                                     │
+│   ┌────────────────────┼────────────────────────────────┐   │
+│   │                    ▼                                 │   │
+│   │   ┌──────────┐  ┌──────────┐  ┌──────────┐          │   │
+│   │   │  Modes   │  │ Synthesis│  │   Cron   │          │   │
+│   │   │  (6)     │  │  (LLM)   │  │ Scheduler│          │   │
+│   │   └────┬─────┘  └────┬─────┘  └────┬─────┘          │   │
+│   │        │             │             │                 │   │
+│   │        └─────────────┼─────────────┘                 │   │
+│   │                      ▼                               │   │
+│   │            ┌──────────────────┐                      │   │
+│   │            │  SQLite Store    │                      │   │
+│   │            │  (async)         │                      │   │
+│   │            └──────────────────┘                      │   │
+│   └──────────────────────────────────────────────────────┘   │
+│                        │                                     │
+│   ┌────────────────────┼────────────────────────────────┐   │
+│   │                    ▼      Gatherers                   │   │
+│   │   ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐   │   │
+│   │   │ Discord │ │ GitHub  │ │    X    │ │  Gmail  │   │   │
+│   │   │TinyFish │ │API      │ │TinyFish │ │TinyFish │   │   │
+│   │   └────┬────┘ └────┬────┘ └────┬────┘ └────┬────┘   │   │
+│   └────────┼───────────┼───────────┼───────────┼─────────┘   │
+└────────────┼───────────┼───────────┼───────────┼─────────────┘
+             │           │           │           │
+         ┌───┴───┐   ┌───┴───┐   ┌───┴───┐   ┌───┴───┐
+         │Discord│   │GitHub │   │   X   │   │ Gmail │
+         └───────┘   └───────┘   └───────┘   └───────┘
+```
+
+## Core Components
+
+### 1. Gatherers
+Collect commitments from external sources.
+
+| Source | Method | When |
+|--------|--------|------|
+| Discord | TinyFish SSE | No API for message search |
+| GitHub | REST API | Issues assigned, PRs awaiting review |
+| X (Twitter) | TinyFish SSE | DMs, bookmarks |
+| Gmail | TinyFish SSE | Actionable emails |
+
+**Base Pattern**:
+```python
+class BaseGatherer(ABC):
+    @abstractmethod
+    async def gather(self) -> AsyncIterator[Commitment]: ...
+    
+    async def run(self) -> GatherResult:
+        # Collect all commitments, return result
+```
+
+### 2. SQLite Store
+Async persistence with SQLAlchemy ORM.
+
+```python
+class CommitmentRow(Base):
+    id: str              # UUID
+    source: str          # discord, github, x_dm, x_bookmark, gmail
+    text: str            # Original message
+    extracted_task: str  # AI-extracted task
+    deadline: datetime   # Optional
+    priority: int        # 0-3
+    status: str          # pending, done, ignored, expired
+    raw_data: JSON       # Full original data
+```
+
+### 3. AI Synthesis
+LiteLLM-based filtering and prioritization.
+
+```python
+async def extract_commitment(text, source) -> dict
+async def filter_commitments(commitments) -> List[Commitment]
+async def prioritize_commitments(commitments) -> List[Commitment]
+async def pick_one_thing(commitments) -> Commitment
+```
+
+**Fallback**: Works without LLM API key (simple priority sorting).
+
+### 4. Cron Scheduler
+Hermes-style file-based scheduler with tick pattern.
+
+```python
+class CronScheduler:
+    def register(name, job_func)
+    def run_in_background()
+    # Uses fcntl for file locking
+    # Tick every 60 seconds
+```
+
+**Jobs**:
+- `gather_all` (every 5 min)
+- `reduce_all` (every 10 min)
+- `expire_old` (every hour)
+
+### 5. Modes
+Six interaction modes for different mental states.
+
+| Mode | State | Behavior |
+|------|-------|----------|
+| One-Thing | Drowning | Show only ONE commitment |
+| Gather | Scattered | Pull from all sources |
+| Reduce | Accumulated | Filter noise, keep what matters |
+| Conversation | Stuck | Thinking partner chat |
+| Just-in-Time | Specific | Ask and receive, no storage |
+| Executor | Ready | Agents handle tasks |
+
+## Data Flow
+
+```
+1. User connects accounts (Discord, GitHub, X, Gmail)
+2. Cron jobs gather commitments periodically
+3. AI synthesis filters and prioritizes
+4. Modes surface based on user's state
+5. User acts (done, skip, delegate)
+6. Status updates reflect in stats
+```
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|------------|
+| Frontend | Next.js 16, Tailwind, Bun |
+| Backend | FastAPI, uvicorn |
+| Storage | SQLite (async) + SQLAlchemy |
+| AI | LiteLLM (any provider) |
+| Scraping | TinyFish (authenticated browser) |
+| Cron | Hermes-style file-based |
+| Runtime | Python 3.13, uv |
+
+## Key Design Decisions
+
+### Why TinyFish?
+Discord and X have no APIs for message search. TinyFish provides authenticated browser automation via SSE streaming.
+
+### Why SQLite?
+Simple, async, no server needed. Perfect for personal tool.
+
+### Why 6 Modes?
+Different chaos states need different interactions. One-size-fits-all doesn't work.
+
+### Why Fallback Mode?
+Production should work without LLM. Simple priority sorting is better than nothing.
+
+## File Structure
+
+```
+order/
+├── src/order/
+│   ├── core/           # Models, config, store
+│   ├── gatherers/      # TinyFish + API gatherers
+│   ├── synthesis/      # LLM integration
+│   ├── modes/          # 6 interaction modes
+│   ├── cron/           # Background jobs
+│   └── api.py          # FastAPI endpoints
+│
+└── frontend/
+    ├── app/            # Next.js pages
+    ├── components/     # Mode views
+    └── lib/            # API client
+```
+
+## Security Considerations
+
+- API keys stored in environment variables
+- No user data stored permanently (commitments expire)
+- TinyFish handles authentication (no credentials stored)
+- Fallback mode works without external APIs

--- a/docs/manifesto.md
+++ b/docs/manifesto.md
@@ -1,0 +1,141 @@
+# Order Manifesto
+
+## The Problem
+
+Your commitments are scattered. Discord messages, GitHub issues, X DMs, emails—each holds a piece of what you promised to do. 
+
+You tried Notion. You tried Obsidian. You tried every todo app.
+
+They all failed for the same reason: **they require you to do the work**.
+
+- Open the app
+- Write down what you need to do
+- Organize it
+- Check it later
+- Feel guilty when you don't
+
+This is **productivity theater**. It's not solving the problem—it's creating new work.
+
+## The Real Problem
+
+In the AI era, the problem isn't organization. It's:
+
+1. **Context Collapse** - Your commitments live in 10 different places
+2. **Information Bankruptcy** - You can't remember what you promised
+3. **Attention Fragmentation** - Every tool demands its own context
+4. **Cognitive Overload** - More tools = more mental load
+
+The average knowledge worker has **commitments scattered across 5+ platforms**. Each one invisible to the others.
+
+You don't need a better tool. You need **something that finds what you already said you'd do**.
+
+## The Solution
+
+**Order** doesn't ask you to organize. It finds what you already promised.
+
+### Core Principles
+
+1. **Zero Setup** - Connect accounts, done. No methodology to learn.
+2. **Pull, Don't Push** - We find your commitments. You don't enter them.
+3. **Multiple Paths** - Different chaos states need different interactions.
+4. **Radical Simplicity** - One-Thing mode shows only ONE commitment.
+5. **Always Fresh** - Background jobs keep it updated automatically.
+6. **Agentic** - Not just tracking. Agents can handle tasks.
+
+### Why 6 Modes?
+
+Because chaos isn't one-dimensional.
+
+| State | What You Feel | What You Need |
+|-------|---------------|---------------|
+| Drowning | "I can't think" | ONE thing |
+| Scattered | "I don't know what I promised" | Gather all |
+| Stuck | "I know but I can't start" | Thinking partner |
+| Accumulated | "Too much on my plate" | Filter noise |
+| Specific | "What about X?" | Just-in-time answer |
+| Ready | "Let's do this" | Execute |
+
+One-size-fits-all doesn't work. You need different tools for different states.
+
+### Why TinyFish?
+
+Discord and X don't have APIs for message search. But that's where your commitments live.
+
+TinyFish provides authenticated browser automation. We can:
+- Search Discord messages for promises
+- Find X DMs and bookmarks
+- Process Gmail for actionable emails
+
+No manual entry. No copying. Just connect and done.
+
+## The Anti-Productivity Product
+
+Order is the **anti-Notion**.
+
+| Notion | Order |
+|--------|-------|
+| Manual entry | Automatic gathering |
+| Single workspace | Multi-source sync |
+| You organize | AI filters |
+| Learning curve | Zero setup |
+| More tools | Less tools |
+| Productivity theater | Pull your actual commitments |
+
+## The Philosophy
+
+### 1. Life is Chaos
+Stop pretending you'll organize it. You won't. We know.
+
+### 2. Commitments are Scattered
+They live where you made them. Go find them there.
+
+### 3. One Thing at a Time
+When drowning, you don't need 100 commitments. You need ONE.
+
+### 4. Context is Everything
+Different states need different tools. Match the tool to the state.
+
+### 5. Less is More
+No features you won't use. No setup you'll skip. No learning curve.
+
+## The Vision
+
+**Order** brings order to chaos without requiring you to change.
+
+- Connect your accounts once
+- Background jobs keep it fresh
+- AI surfaces what matters
+- You act when ready
+
+No manual entry. No organization. No guilt.
+
+**Just order from chaos.**
+
+---
+
+## For the Hackathon
+
+This is a TinyFish-powered demo for the HackerEarth pre-accelerator.
+
+**What we're building:**
+- TinyFish gatherers for Discord, X, Gmail
+- GitHub API for issues/PRs
+- 6 interaction modes
+- AI synthesis with LiteLLM
+- Background cron jobs
+
+**What we're proving:**
+- Pulling commitments from scattered sources works
+- Multiple modes for different chaos states is valuable
+- Zero-setup productivity is possible
+
+**What we're NOT building:**
+- Another Notion
+- Another todo app
+- Another productivity methodology
+
+**We're building** the thing that finds what you already promised.
+
+---
+
+*Order brings order to chaos. Not by adding more tools, but by finding what's already there.*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,203 @@
+# Roadmap
+
+## TinyFish Hackathon Sprint
+
+**Goal**: Demo-ready for HackerEarth pre-accelerator submission
+
+**Timeline**: 2-3 weeks
+
+---
+
+## Phase 1: MVP Foundation (Week 1)
+
+### Goal
+Get core functionality working end-to-end.
+
+### Tasks
+- [ ] Backend runs without errors
+- [ ] Frontend connects to backend
+- [ ] One-Thing mode works
+- [ ] Gather mode shows mock data
+- [ ] Basic error handling
+- [ ] README with setup instructions
+
+### Acceptance Criteria
+- `uv run uvicorn order.api:app` starts server
+- `bun run dev` shows frontend
+- Clicking through modes doesn't crash
+- At least one commitment shows in One-Thing
+
+### GitHub Issues
+- #1 MVP Demo Ready
+- #11 6 Modes End-to-End Testing
+
+---
+
+## Phase 2: Integrations + AI (Week 1-2)
+
+### Goal
+Real data flowing from sources, AI working.
+
+### Tasks
+- [ ] TinyFish API key configuration
+- [ ] Discord gatherer with real account
+- [ ] X (Twitter) gatherer with real account
+- [ ] GitHub gatherer with real PAT
+- [ ] Gmail gatherer with real account
+- [ ] Test AI synthesis quality
+- [ ] Add fallback mode
+
+### Acceptance Criteria
+- All 4 sources show as connected
+- Gather pulls real commitments
+- AI filters noise correctly
+- Works without LLM API key
+
+### GitHub Issues
+- #2 Source Integrations
+- #10 AI Synthesis Quality
+
+---
+
+## Phase 3: Polish + Pitch (Week 2)
+
+### Goal
+Production-ready for demo, compelling pitch.
+
+### Tasks
+- [ ] Improve mode selector UX
+- [ ] Add loading states
+- [ ] Add animations/transitions
+- [ ] Error states with retry
+- [ ] Empty states
+- [ ] Source icons
+- [ ] Deadline indicators
+- [ ] Create pitch deck (8-10 slides)
+- [ ] Record demo video (60-90s)
+
+### Acceptance Criteria
+- Feels like a polished product
+- Pitch deck ready
+- Demo video uploaded
+
+### GitHub Issues
+- #3 Frontend Polish
+- #4 Pitch Deck
+- #5 Demo Video
+
+---
+
+## Phase 4: Deployment (Week 2-3)
+
+### Goal
+Live demo URL for judges.
+
+### Tasks
+- [ ] Deploy backend to Railway/Fly.io
+- [ ] Deploy frontend to Vercel
+- [ ] Set environment variables
+- [ ] Test all endpoints
+- [ ] Add deployment badges
+
+### Acceptance Criteria
+- Live URL works
+- All API endpoints accessible
+- Frontend connects to backend
+
+### GitHub Issues
+- #6 Deployment
+
+---
+
+## Hackathon Submission Checklist
+
+- [ ] Working demo (live URL or video)
+- [ ] Pitch deck (PDF)
+- [ ] Demo video (60-90s)
+- [ ] Code repository (public)
+- [ ] README with setup
+- [ ] TinyFish integration prominent
+
+---
+
+## Post-Hackathon Roadmap
+
+### Phase 5: Production Ready
+- Rate limiting
+- Input validation
+- Proper CORS
+- Error logging
+- Health monitoring
+- **Issue #7 Security**
+
+### Phase 6: Quality of Life
+- Email digests
+- Mobile responsive polish
+- Keyboard shortcuts
+- Better error messages
+- **Issue #8 Email Digest**
+
+### Phase 7: Scale
+- Multi-user support
+- Team workspaces
+- Shared commitments
+- Integrations (Slack, Teams)
+- Webhooks
+
+### Phase 8: Intelligence
+- Better AI extraction
+- Deadline prediction
+- Commitment patterns
+- Smart reminders
+- Priority learning
+
+---
+
+## Success Metrics
+
+### Hackathon
+- ✅ Demo works live
+- ✅ Pitch deck compelling
+- ✅ TinyFish integration shown
+- ✅ All 6 modes functional
+
+### Post-Hackathon
+- Real users actually using it
+- Commitments gathered per week
+- Time saved vs manual organization
+- User retention
+
+---
+
+## Timeline Visualization
+
+```
+Week 1          Week 2          Week 3
+├───────────────┼───────────────┼───────────────┤
+│ Phase 1       │ Phase 3       │ Phase 4       │
+│ MVP           │ Polish        │ Deploy        │
+│               │               │               │
+│ Phase 2       │ Phase 3       │ SUBMISSION    │
+│ Integrations  │ Pitch/Video   │               │
+└───────────────┴───────────────┴───────────────┘
+```
+
+---
+
+## What We're NOT Doing
+
+- ❌ Mobile app (web first)
+- ❌ Multi-user (personal tool first)
+- ❌ Team features (solo first)
+- ❌ Manual entry (pull only)
+- ❌ Another methodology (zero setup)
+
+---
+
+## The Focus
+
+**MVP → Demo → Submit → Iterate**
+
+Get it working. Get it to judges. Get feedback. Build more.
+
+*"We got no users so no need to worry about old things"* — Ash-Blanc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,16 @@ dependencies = [
 [project.scripts]
 order = "order.__main__:main"
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "httpx>=0.28",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Shared fixtures for all tests"""
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+
+from order.api import app
+from order.core.store import store
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def init_db(tmp_path, monkeypatch):
+    """Use a fresh in-memory SQLite DB for each test."""
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+    from sqlalchemy.orm import sessionmaker
+    from order.core.store import Base
+
+    engine = create_async_engine(db_url, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    SessionLocal = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    monkeypatch.setattr(store, "engine", engine)
+    monkeypatch.setattr(store, "async_session", SessionLocal)
+
+    yield
+
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client():
+    """Return an async test client for the FastAPI app."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac

--- a/tests/test_api_modes.py
+++ b/tests/test_api_modes.py
@@ -1,0 +1,127 @@
+"""E2E tests for all 6 API modes via the FastAPI test client"""
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestHealth:
+    async def test_health(self, client):
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    async def test_root(self, client):
+        resp = await client.get("/")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Order"
+
+
+class TestOneThing:
+    async def test_empty_store_returns_empty_status(self, client):
+        resp = await client.get("/api/one-thing")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "empty"
+
+    async def test_done_missing_id_returns_error(self, client):
+        resp = await client.post("/api/one-thing/done", json={"commitment_id": "nonexistent"})
+        assert resp.status_code == 200  # store silently ignores unknown ids
+
+    async def test_skip_missing_id_returns_ok(self, client):
+        resp = await client.post("/api/one-thing/skip", json={"commitment_id": "nonexistent"})
+        assert resp.status_code == 200
+
+    async def test_why_missing_id_returns_404(self, client):
+        resp = await client.get("/api/one-thing/why?commitment_id=nonexistent")
+        assert resp.status_code == 404
+
+
+class TestStats:
+    async def test_stats_empty(self, client):
+        resp = await client.get("/api/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pending"] == 0
+        assert data["done"] == 0
+
+
+class TestGather:
+    async def test_test_connections(self, client):
+        resp = await client.get("/api/gather/test")
+        assert resp.status_code == 200
+        # All connections should return False when no API keys are set
+        data = resp.json()
+        assert isinstance(data, dict)
+        for connected in data.values():
+            assert connected is False
+
+    async def test_gather_all_no_keys_returns_done(self, client):
+        resp = await client.get("/api/gather")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "done"
+        assert isinstance(resp.json()["results"], list)
+
+
+class TestReduce:
+    async def test_reduce_empty_store(self, client):
+        resp = await client.get("/api/reduce")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["filtered_count"] == 0
+        assert data["kept_count"] == 0
+
+
+class TestConversation:
+    async def test_chat_responds(self, client):
+        resp = await client.post("/api/chat", json={"message": "What should I focus on?"})
+        assert resp.status_code == 200
+        assert "response" in resp.json()
+
+    async def test_chat_empty_message_rejected(self, client):
+        resp = await client.post("/api/chat", json={"message": "   "})
+        assert resp.status_code == 422
+
+    async def test_chat_too_long_rejected(self, client):
+        resp = await client.post("/api/chat", json={"message": "x" * 2001})
+        assert resp.status_code == 422
+
+    async def test_reset_chat(self, client):
+        resp = await client.post("/api/chat/reset")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "reset"
+
+
+class TestJustInTime:
+    async def test_search_empty_store(self, client):
+        resp = await client.post("/api/search", json={"query": "review PR"})
+        assert resp.status_code == 200
+        assert resp.json()["results"] == []
+
+    async def test_search_empty_query_rejected(self, client):
+        resp = await client.post("/api/search", json={"query": ""})
+        assert resp.status_code == 422
+
+    async def test_promises_empty_store(self, client):
+        resp = await client.get("/api/promises")
+        assert resp.status_code == 200
+        assert resp.json()["results"] == []
+
+    async def test_about_empty_store(self, client):
+        resp = await client.get("/api/about?topic=report")
+        assert resp.status_code == 200
+        assert resp.json()["results"] == []
+
+
+class TestExecutor:
+    async def test_list_commitments_empty(self, client):
+        resp = await client.get("/api/commitments")
+        assert resp.status_code == 200
+        assert resp.json()["commitments"] == []
+
+    async def test_get_commitment_not_found(self, client):
+        resp = await client.get("/api/commitments/nonexistent")
+        assert resp.status_code == 404
+
+    async def test_propose_action_not_found(self, client):
+        resp = await client.post("/api/commitments/nonexistent/action")
+        assert resp.status_code == 404

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,91 @@
+"""Unit tests for the Store layer"""
+import pytest
+from datetime import datetime, timedelta
+
+from order.core.models import Commitment, CommitmentStatus, Source
+from order.core.store import store
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_commitment(platform_id: str = "p1", priority: int = 1) -> Commitment:
+    return Commitment(
+        source=Source.GITHUB,
+        text="Review the PR",
+        extracted_task="Review PR #123",
+        platform_id=platform_id,
+        platform_url="https://github.com/org/repo/pull/123",
+        priority=priority,
+    )
+
+
+class TestAdd:
+    async def test_add_and_retrieve(self):
+        c = _make_commitment()
+        await store.add(c)
+        all_items = await store.get_all()
+        assert len(all_items) == 1
+        assert all_items[0].id == c.id
+
+    async def test_add_many_deduplicates_by_platform_id(self):
+        c1 = _make_commitment("same-id")
+        c2 = _make_commitment("same-id")
+        await store.add_many([c1, c2])
+        all_items = await store.get_all()
+        assert len(all_items) == 1
+
+
+class TestGetPending:
+    async def test_pending_ordered_by_priority(self):
+        low = _make_commitment("low", priority=0)
+        high = _make_commitment("high", priority=3)
+        await store.add_many([low, high])
+        pending = await store.get_pending()
+        assert pending[0].priority >= pending[-1].priority
+
+    async def test_done_not_in_pending(self):
+        c = _make_commitment()
+        await store.add(c)
+        await store.update_status(c.id, CommitmentStatus.DONE)
+        pending = await store.get_pending()
+        assert all(p.id != c.id for p in pending)
+
+
+class TestExpireOld:
+    async def test_expire_old_marks_as_expired(self):
+        c = _make_commitment()
+        await store.add(c)
+
+        # Artificially age the row
+        from sqlalchemy import update
+        from order.core.store import CommitmentRow
+        async with store.async_session() as session:
+            await session.execute(
+                update(CommitmentRow)
+                .where(CommitmentRow.id == c.id)
+                .values(created_at=datetime.utcnow() - timedelta(hours=73))
+            )
+            await session.commit()
+
+        expired_count = await store.expire_old(hours=72)
+        assert expired_count == 1
+        pending = await store.get_pending()
+        assert all(p.id != c.id for p in pending)
+
+    async def test_recent_items_not_expired(self):
+        c = _make_commitment()
+        await store.add(c)
+        expired_count = await store.expire_old(hours=72)
+        assert expired_count == 0
+
+
+class TestCountByStatus:
+    async def test_counts_are_accurate(self):
+        c1 = _make_commitment("id1")
+        c2 = _make_commitment("id2")
+        await store.add_many([c1, c2])
+        await store.update_status(c1.id, CommitmentStatus.DONE)
+        counts = await store.count_by_status()
+        assert counts["pending"] == 1
+        assert counts["done"] == 1


### PR DESCRIPTION
## Summary
Zero test coverage made it hard to confidently iterate before the demo. This adds smoke tests for every API endpoint and unit tests for the store layer.

## Changes
- `tests/conftest.py`: per-test isolated in-memory SQLite + async test client
- `tests/test_api_modes.py`: covers all 6 modes (One-Thing, Gather, Reduce, Conversation, Just-in-Time, Executor), Health, Stats — empty-store cases and input validation
- `tests/test_store.py`: `add`, `add_many` deduplication, `get_pending` ordering, `expire_old`, `update_status`, `count_by_status`
- `pyproject.toml`: add `[project.optional-dependencies] dev` group + `asyncio_mode = auto`

## How to run
```bash
uv sync --extra dev
uv run pytest tests/ -v
```

## Test plan
- [ ] All tests pass with `uv run pytest tests/ -v`
- [ ] Tests pass with no `.env` file present (no API keys needed)

Closes #11